### PR TITLE
chore: removed FileSize component from helpers

### DIFF
--- a/packages/utils/helpers.js
+++ b/packages/utils/helpers.js
@@ -11,8 +11,6 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-import React from 'react';
-
 import pluralize from 'pluralize';
 import Cookies from 'universal-cookie';
 
@@ -238,13 +236,6 @@ export const getFormattedSize = bytes => {
   }
   return `${(bytes / Math.pow(1024, i)).toFixed(2)} ${suffixes[i]}`;
 };
-
-export const FileSize = React.forwardRef(({ fileSize, style }, ref) => (
-  <div ref={ref} style={style}>
-    {getFormattedSize(fileSize)}
-  </div>
-));
-FileSize.displayName = 'FileSize';
 
 const collectAddressesFrom = devices =>
   devices.reduce((collector, { attributes = {} }) => {

--- a/packages/utils/helpers.test.js
+++ b/packages/utils/helpers.test.js
@@ -11,12 +11,8 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-import React from 'react';
-
-import { defaultState, undefineds } from '../../tests/mockData';
-import { render } from '../../tests/setupTests';
+import { defaultState } from '../../tests/mockData';
 import {
-  FileSize,
   customSort,
   deepCompare,
   detectOsIdentifier,
@@ -38,16 +34,6 @@ import {
 } from './helpers';
 
 const deploymentCreationTime = defaultState.deployments.byId.d1.created;
-
-/* eslint-disable sonarjs/no-duplicate-string */
-describe('FileSize Component', () => {
-  it('renders correctly', async () => {
-    const { baseElement } = render(<FileSize fileSize={1000} />);
-    const view = baseElement.firstChild.firstChild;
-    expect(view).toMatchSnapshot();
-    expect(view).toEqual(expect.not.stringMatching(undefineds));
-  });
-});
 
 describe('getFormattedSize function', () => {
   it('converts correctly', async () => {
@@ -340,7 +326,6 @@ describe('deepCompare function', () => {
     const date = new Date();
     expect(deepCompare(date, date)).toBeTruthy();
     expect(deepCompare(date, new Date().setDate(date.getDate() - 1))).toBeFalsy();
-    expect(deepCompare(<FileSize />, <FileSize />)).toBeTruthy();
     expect(deepCompare(defaultState, {})).toBeFalsy();
   });
 });


### PR DESCRIPTION
FileSize is no longer part of helper. It was moved to common components https://github.com/mendersoftware/mender-server/pull/153

ChangeLog: None

Ticket: None