### PR TITLE
ci: release job as .post

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,12 +9,6 @@ variables:
   GITHUB_USER_EMAIL:
     description: 'The Github user email for release-please'
     value: 'mender@northern.tech'
-  RUN_RELEASE:
-    description: 'Run a new release'
-    value: 'false'
-    options:
-      - 'true'
-      - 'false'
   GIT_CLIFF:
     description: 'Run git cliff to override the release-please changelog'
     value: 'true'
@@ -70,8 +64,6 @@ changelog:
     GIT_DEPTH: 0 # Always get the full history
     GIT_STRATEGY: clone
   rules:
-    - if: $RUN_RELEASE == "true"
-      when: never
     - if: $CI_COMMIT_BRANCH =~ "/^\d+\.\d+\.x$/"
     - if: $CI_COMMIT_BRANCH == $DEFAULT_BRANCH
   before_script:
@@ -133,10 +125,16 @@ changelog:
     - git remote remove github-${CI_JOB_ID}
 
 release:github:
-  stage: release
+  stage: .post
   rules:
-    - if: $CI_COMMIT_BRANCH =~ "/^\d+\.\d+\.x$/" && $RUN_RELEASE == "true"
-    - if: $CI_COMMIT_BRANCH == $DEFAULT_BRANCH && $RUN_RELEASE == "true"
+    - if: $CI_COMMIT_BRANCH =~ "/^\d+\.\d+\.x$/" # Release from maintenance branches
+      when: manual
+      allow-failure: true
+    - if: $CI_COMMIT_BRANCH == $DEFAULT_BRANCH
+      when: manual
+      allow-failure: true
+  needs:
+    - job: changelog
   script:
     - npm install -g release-please
     - npm ci


### PR DESCRIPTION
You can have an optional manual release in the same pipeline, right after it's finished successfully, and you have merged down the changelog PR.