### PR TITLE
ci: update CHANGELOG.md even without any changes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -104,15 +104,12 @@ changelog:
     # deal with the component's changelogs
     - |
       for component in $(jq -r 'keys[] | select(. != ".")' .release-please-manifest.json); do
-        echo "DEBUG - component $component starting";
         component_name=$(echo "$component" | cut -d'/' -f2);
-        echo "DEBUG - component_name- $component_name";
         RELEASE_PLEASE_PR=$(gh pr list --author "${GITHUB_USER_NAME}" --head "release-please--branches--${CI_COMMIT_REF_NAME}" --search "${component_name}" --json number --jq '.[0].number');
         if [[ -z "$RELEASE_PLEASE_PR" ]]; then
-          echo "DEBUG - no PR found for $component_name";
+          echo "INFO - no PR found for $component_name";
           continue;
         fi
-        echo "DEBUG - component $component, component_name $component_name, RELEASE_PLEASE_PR $RELEASE_PLEASE_PR";
         gh pr checkout --force $RELEASE_PLEASE_PR;
         cd $component;
           wget --output-document cliff.toml https://raw.githubusercontent.com/mendersoftware/mendertesting/master/utils/cliff.toml.scoped;
@@ -121,19 +118,12 @@ changelog:
           git add CHANGELOG.md;
           git commit --amend -s --no-edit;
           git push github-${CI_JOB_ID} --force;
-          echo "DEBUG - pushed to github";
-          echo "DEBUG - running git cliff to update the pr body";
           git cliff --unreleased --bump -o tmp_pr_body.md --repository "../../" --include-path "${component}/**/*" --github-repo ${GITHUB_REPO_URL} --tag-pattern "${component_name}.*";
-          echo "DEBUG - edit the pr body";
           gh pr edit $RELEASE_PLEASE_PR --body-file tmp_pr_body.md;
-          echo "DEBUG - remove temp file";
           rm tmp_pr_body.md;
         cd ../..;
-        echo "DEBUG - i'm inside $PWD folder";
       done
-      echo "DEBUG - releasing components done"
   after_script:
-    - echo "DEBUG - failed with $CI_JOB_EXIT_CODE"
     - git remote remove github-${CI_JOB_ID}
 
 release:github:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -91,7 +91,7 @@ changelog:
       if [[ "${RELEASE_PLEASE_PR}" != "notfound" ]]; then
         gh pr checkout --force $RELEASE_PLEASE_PR
         wget --output-document cliff.toml https://raw.githubusercontent.com/mendersoftware/mendertesting/master/utils/cliff.toml.scoped
-        git cliff --unreleased --bump --output CHANGELOG.md --github-repo ${GITHUB_REPO_URL}
+        git cliff --bump --output CHANGELOG.md --github-repo ${GITHUB_REPO_URL}
         git add CHANGELOG.md
         git commit --amend -s --no-edit
         git push github-${CI_JOB_ID} --force
@@ -116,8 +116,7 @@ changelog:
         gh pr checkout --force $RELEASE_PLEASE_PR;
         cd $component;
           wget --output-document cliff.toml https://raw.githubusercontent.com/mendersoftware/mendertesting/master/utils/cliff.toml.scoped;
-          git cliff --unreleased --bump --output ./CHANGELOG.md --repository "../../" --include-path "${component}/**/*" --github-repo ${GITHUB_REPO_URL} --tag-pattern "${component_name}.*";
-          echo "DEBUG - list current CHANGELOG";
+          git cliff --bump --output ./CHANGELOG.md --repository "../../" --include-path "${component}/**/*" --github-repo ${GITHUB_REPO_URL} --tag-pattern "${component_name}.*";
           cat CHANGELOG.md;
           git add CHANGELOG.md;
           git commit --amend -s --no-edit;


### PR DESCRIPTION
I'm not 100% sure about this: the PR body will be still empty, but at least the CHANGELOG.md would be populated..