### PR TITLE
fix: added missing release config entries for helptips & common-ui packages

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,11 +1,11 @@
 {
   ".": "0.1.1",
+  "packages/common-ui": "0.0.1",
   "packages/common": "0.1.0",
   "packages/eslint-config": "0.1.1",
+  "packages/helptips": "0.0.1",
   "packages/prettier-config": "0.1.0",
   "packages/store": "0.1.2",
   "packages/typescript-config": "0.1.0",
-  "packages/utils": "0.1.2",
-  "packages/common-ui": "0.0.1",
-  "packages/helptips": "0.0.1"
+  "packages/utils": "0.1.2"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -15,7 +15,13 @@
     "packages/common": {
       "release-type": "node"
     },
+    "packages/common-ui": {
+      "release-type": "node"
+    },
     "packages/eslint-config": {
+      "release-type": "node"
+    },
+    "packages/helptips": {
       "release-type": "node"
     },
     "packages/prettier-config": {


### PR DESCRIPTION
was wondering why there was no release PR created 😬 