### PR TITLE
added product selection

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -180,7 +180,7 @@ pages:
     GITHUB_STATUS_API_JSON_F: '{"state": "%s", "context": "ci/storybook", "target_url": "%s", "description": "%s"}'
     PAGES_PREFIX: ''
   script:
-    - json="$(printf "$GITHUB_STATUS_API_JSON_F" "success" "${CI_PAGES_URL}/${PAGES_PREFIX//_/-}" "Storybook deployed")"
+    - json="$(printf "$GITHUB_STATUS_API_JSON_F" "success" "${CI_PAGES_URL}" "Storybook deployed")"
     - curl -f -H "$GITHUB_AUTH" -d "$json" "$GITHUB_STATUS_API_URL"
   pages:
     path_prefix: '$PAGES_PREFIX'

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -19,10 +19,6 @@ const config: StorybookConfig = {
       ...config,
       define: { 'process.env': {} }
     };
-  },
-
-  docs: {
-    autodocs: true
   }
 };
 

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,7 +1,7 @@
 import type { Preview } from '@storybook/react';
 import { initialize as initializeMSW, mswLoader } from 'msw-storybook-addon';
 
-import { defaultTheme, globalThemeType, withMuiTheme } from './utils/themeUtils';
+import { defaultProduct, defaultTheme, globalProductType, globalThemeType, withMuiTheme } from './utils/themeUtils';
 
 initializeMSW();
 
@@ -17,9 +17,10 @@ const preview: Preview = {
   },
   decorators: [withMuiTheme],
   globalTypes: {
+    product: globalProductType,
     theme: globalThemeType
   },
-  initialGlobals: { theme: defaultTheme },
+  initialGlobals: { theme: defaultTheme, product: defaultProduct },
   loaders: [mswLoader],
   tags: ['autodocs']
 };

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -20,7 +20,8 @@ const preview: Preview = {
     theme: globalThemeType
   },
   initialGlobals: { theme: defaultTheme },
-  loaders: [mswLoader]
+  loaders: [mswLoader],
+  tags: ['autodocs']
 };
 
 export default preview;

--- a/.storybook/utils/themeUtils.tsx
+++ b/.storybook/utils/themeUtils.tsx
@@ -2,8 +2,10 @@ import { useMemo } from 'react';
 
 import { CssBaseline, ThemeProvider, createTheme, styled } from '@mui/material';
 
-import { dark as darkTheme, light as lightTheme } from '../../packages/themes/src/Mender/index';
-import '../../packages/themes/src/Mender/styles/main.less';
+import { dark as darkAlvaldiTheme, light as lightAlvaldiTheme } from '@northern.tech/themes/Alvaldi';
+import { dark as darkCFEngineTheme, light as lightCFEngineTheme } from '@northern.tech/themes/CFEngine';
+import { dark as darkMenderTheme, light as lightMenderTheme } from '@northern.tech/themes/Mender';
+import '@northern.tech/themes/Mender/styles/main.css';
 
 const reducePalette =
   prefix =>
@@ -34,15 +36,28 @@ const cssVariables = ({ theme: { palette } }) => {
 const WrappedBaseline = styled(CssBaseline)(cssVariables);
 
 const THEMES = {
-  light: lightTheme,
-  dark: darkTheme
+  Alvaldi: {
+    id: 'Alvaldi',
+    light: lightAlvaldiTheme,
+    dark: darkAlvaldiTheme
+  },
+  Mender: {
+    id: 'Mender',
+    light: lightMenderTheme,
+    dark: darkMenderTheme
+  },
+  CFEngine: {
+    id: 'CFEngine',
+    light: lightCFEngineTheme,
+    dark: darkCFEngineTheme
+  }
 };
 
 export const withMuiTheme = (Story, context) => {
-  const { theme: themeKey } = context.globals;
+  const { product, theme: themeKey } = context.globals;
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
-  const theme = useMemo(() => createTheme(THEMES[themeKey] || THEMES['light']), [themeKey]);
+  const theme = useMemo(() => createTheme(THEMES[product][themeKey] || THEMES.Mender.light), [product, themeKey]);
 
   return (
     <ThemeProvider theme={theme}>
@@ -66,3 +81,19 @@ export const globalThemeType = {
 };
 
 export const defaultTheme = 'light';
+
+export const globalProductType = {
+  name: 'Product',
+  title: 'Product',
+  toolbar: {
+    icon: 'repository',
+    dynamicTitle: true,
+    items: [
+      { value: THEMES.Alvaldi.id, title: THEMES.Alvaldi.id },
+      { value: THEMES.Mender.id, title: THEMES.Mender.id },
+      { value: THEMES.CFEngine.id, title: THEMES.CFEngine.id }
+    ]
+  }
+};
+
+export const defaultProduct = THEMES.Mender.id;

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@emotion/jest": "^11.13.0",
         "@northern.tech/eslint-config": "*",
         "@northern.tech/prettier-config": "*",
+        "@northern.tech/themes": "*",
         "@northern.tech/typescript-config": "*",
         "@storybook/addon-actions": "^8.5.3",
         "@storybook/addon-essentials": "^8.5.3",
@@ -37,7 +38,7 @@
         "msw-storybook-addon": "^2.0.4",
         "react-idle-timer": "^5.7.2",
         "serve": "^14.2.4",
-        "storybook": "^8.2.6",
+        "storybook": "^8.5.3",
         "tsup": "8.3.6",
         "turbo": "^2.4.0",
         "typescript": "^5.7.3",
@@ -15732,9 +15733,9 @@
       }
     },
     "node_modules/unplugin": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.16.0.tgz",
-      "integrity": "sha512-5liCNPuJW8dqh3+DM6uNM2EI3MLLpCKp/KY+9pB5M2S2SR2qvvDHhKgBOaTWEbZTAws3CXfB0rKTIolWKL05VQ==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.16.1.tgz",
+      "integrity": "sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16708,7 +16709,7 @@
     },
     "packages/common": {
       "name": "@northern.tech/common",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@mui/icons-material": "^6.x",
@@ -16737,7 +16738,7 @@
     },
     "packages/common-ui": {
       "name": "@northern.tech/common-ui",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@mdi/js": "^7.x",
@@ -17092,7 +17093,7 @@
     },
     "packages/typescript-config": {
       "name": "@northern.tech/typescript-config",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "tsup": "8.3.6"
@@ -17100,7 +17101,7 @@
     },
     "packages/utils": {
       "name": "@northern.tech/utils",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "dayjs": "^1.x",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "msw-storybook-addon": "^2.0.4",
     "react-idle-timer": "^5.7.2",
     "serve": "^14.2.4",
-    "storybook": "^8.2.6",
+    "storybook": "^8.5.3",
     "tsup": "8.3.6",
     "turbo": "^2.4.0",
     "typescript": "^5.7.3",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@emotion/jest": "^11.13.0",
     "@northern.tech/eslint-config": "*",
     "@northern.tech/prettier-config": "*",
+    "@northern.tech/themes": "*",
     "@northern.tech/typescript-config": "*",
     "@storybook/addon-actions": "^8.5.3",
     "@storybook/addon-essentials": "^8.5.3",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@northern.tech/typescript-config/react-app.json",
   "compilerOptions": {
+    "moduleResolution": "bundler",
     "rootDir": ".",
     "baseUrl": "."
   },


### PR DESCRIPTION
@aleksandrychev we will need a reference to the red hat font or a fallback font for CFEngine to have this look a little nicer when CFEngine is selected 😉 

example here: https://nt-gui-e21511.gitlab.io/pr-166/?path=/docs/common-src-auditlogs--docs