### PR TITLE
Chore/lint type imports

### DIFF
--- a/packages/common-ui/eslint.config.js
+++ b/packages/common-ui/eslint.config.js
@@ -1,3 +1,10 @@
 import eslintConfigReact from '@northern.tech/eslint-config/react.js';
 
-export default eslintConfigReact;
+export default [
+  ...eslintConfigReact,
+  {
+    rules: {
+      '@typescript-eslint/consistent-type-imports': 'error'
+    }
+  }
+];

--- a/packages/common-ui/src/Alert.tsx
+++ b/packages/common-ui/src/Alert.tsx
@@ -11,7 +11,7 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-import { CSSProperties, ReactNode } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 
 export const Alert = ({ children, className = '', style }: { children: ReactNode; className?: string; style: CSSProperties }) => (
   <div className={className} style={style}>

--- a/packages/common-ui/src/ChipSelect.tsx
+++ b/packages/common-ui/src/ChipSelect.tsx
@@ -11,7 +11,8 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-import { RefObject, useState } from 'react';
+import type { RefObject } from 'react';
+import { useState } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 
 import { Autocomplete, TextField } from '@mui/material';

--- a/packages/common-ui/src/ConfigurationObject.tsx
+++ b/packages/common-ui/src/ConfigurationObject.tsx
@@ -12,7 +12,8 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 //@ts-nocheck
-import React, { CSSProperties, Fragment, ReactNode, useState } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
+import React, { Fragment, useState } from 'react';
 
 // material ui
 import { FileCopyOutlined as CopyToClipboardIcon } from '@mui/icons-material';

--- a/packages/common-ui/src/Confirm.tsx
+++ b/packages/common-ui/src/Confirm.tsx
@@ -11,7 +11,8 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-import { CSSProperties, useState } from 'react';
+import type { CSSProperties } from 'react';
+import { useState } from 'react';
 
 import { Cancel as CancelIcon, CheckCircle as CheckCircleIcon, Check as CheckIcon, Close as CloseIcon, Edit as EditIcon } from '@mui/icons-material';
 import { Button, IconButton } from '@mui/material';

--- a/packages/common-ui/src/ConfirmModal.tsx
+++ b/packages/common-ui/src/ConfirmModal.tsx
@@ -11,9 +11,11 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-import { FormEvent, useState } from 'react';
+import type { FormEvent } from 'react';
+import { useState } from 'react';
 
-import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogProps, DialogTitle, TextField } from '@mui/material';
+import type { DialogProps } from '@mui/material';
+import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, TextField } from '@mui/material';
 
 interface ConfirmModalProps {
   className?: string;

--- a/packages/common-ui/src/CopyCode.tsx
+++ b/packages/common-ui/src/CopyCode.tsx
@@ -12,7 +12,8 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 //@ts-nocheck
-import { CSSProperties, ReactNode, useState } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
+import { useState } from 'react';
 import CopyToClipboard from 'react-copy-to-clipboard';
 
 import { FileCopy as CopyPasteIcon } from '@mui/icons-material';

--- a/packages/common-ui/src/DetailsIndicator.tsx
+++ b/packages/common-ui/src/DetailsIndicator.tsx
@@ -15,7 +15,7 @@
 //@ts-nocheck
 import { ArrowForward as ArrowForwardIcon } from '@mui/icons-material';
 
-import { ClassesOverrides } from './List';
+import type { ClassesOverrides } from './List';
 
 const defaultClasses = { icon: '', wrapper: '' };
 export const DetailsIndicator = ({ classes = defaultClasses }: ClassesOverrides) => {

--- a/packages/common-ui/src/DetailsTable.tsx
+++ b/packages/common-ui/src/DetailsTable.tsx
@@ -12,7 +12,7 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 // material ui
-import { CSSProperties, ReactNode, Ref } from 'react';
+import type { CSSProperties, ReactNode, Ref } from 'react';
 
 import { Sort as SortIcon } from '@mui/icons-material';
 import { Checkbox, Table, TableBody, TableCell, TableHead, TableRow } from '@mui/material';

--- a/packages/common-ui/src/DeviceIdentity.tsx
+++ b/packages/common-ui/src/DeviceIdentity.tsx
@@ -12,12 +12,13 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 //@ts-nocheck
-import { CSSProperties, ReactNode, useMemo } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 import { makeStyles } from 'tss-react/mui';
 
-import { Device } from '@northern.tech/store/api/types/Device';
+import type { Device } from '@northern.tech/store/api/types/Device';
 import { getDeviceById as getDeviceByIdSelector, getIdAttribute } from '@northern.tech/store/selectors';
 import { stringToBoolean } from '@northern.tech/utils/helpers';
 

--- a/packages/common-ui/src/DeviceNameInput.tsx
+++ b/packages/common-ui/src/DeviceNameInput.tsx
@@ -17,7 +17,7 @@ import { useEffect, useRef, useState } from 'react';
 import { InputAdornment, OutlinedInput } from '@mui/material';
 import { makeStyles } from 'tss-react/mui';
 
-import { Device } from '@northern.tech/store/devicesSlice';
+import type { Device } from '@northern.tech/store/devicesSlice';
 import { useAppDispatch } from '@northern.tech/store/store';
 import { setDeviceTags } from '@northern.tech/store/thunks';
 

--- a/packages/common-ui/src/DocsLink.tsx
+++ b/packages/common-ui/src/DocsLink.tsx
@@ -12,7 +12,8 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 //@ts-nocheck
-import { ReactNode, forwardRef, useState } from 'react';
+import type { ReactNode } from 'react';
+import { forwardRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import { Description as DescriptionIcon } from '@mui/icons-material';

--- a/packages/common-ui/src/DrawerTitle.tsx
+++ b/packages/common-ui/src/DrawerTitle.tsx
@@ -12,7 +12,7 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 //@ts-nocheck
-import { FunctionComponent, ReactNode } from 'react';
+import type { FunctionComponent, ReactNode } from 'react';
 
 import { Close as CloseIcon, Link as LinkIcon } from '@mui/icons-material';
 import { IconButton } from '@mui/material';

--- a/packages/common-ui/src/ExpandableAttribute.tsx
+++ b/packages/common-ui/src/ExpandableAttribute.tsx
@@ -11,7 +11,8 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-import { CSSProperties, useCallback, useEffect, useRef, useState } from 'react';
+import type { CSSProperties } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 // material ui
 import { FileCopyOutlined as CopyToClipboardIcon } from '@mui/icons-material';

--- a/packages/common-ui/src/FileSize.tsx
+++ b/packages/common-ui/src/FileSize.tsx
@@ -11,7 +11,8 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //@ts-nocheck
-import React, { ForwardRefRenderFunction, memo } from 'react';
+import type { ForwardRefRenderFunction } from 'react';
+import React, { memo } from 'react';
 
 import { getFormattedSize } from '@northern.tech/utils/helpers';
 

--- a/packages/common-ui/src/InfoHint.tsx
+++ b/packages/common-ui/src/InfoHint.tsx
@@ -11,7 +11,7 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-import { ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
 import { InfoOutlined as InfoOutlinedIcon } from '@mui/icons-material';
 import { makeStyles } from 'tss-react/mui';

--- a/packages/common-ui/src/InfoText.tsx
+++ b/packages/common-ui/src/InfoText.tsx
@@ -11,7 +11,7 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-import { ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
 import { makeStyles } from 'tss-react/mui';
 

--- a/packages/common-ui/src/List.tsx
+++ b/packages/common-ui/src/List.tsx
@@ -12,7 +12,8 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 //@ts-nocheck
-import { CSSProperties, ComponentType, MutableRefObject, ReactElement, useCallback, useEffect, useRef, useState } from 'react';
+import type { CSSProperties, ComponentType, MutableRefObject, ReactElement } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { Settings as SettingsIcon, Sort as SortIcon } from '@mui/icons-material';
 import { Checkbox } from '@mui/material';

--- a/packages/common-ui/src/Loader.tsx
+++ b/packages/common-ui/src/Loader.tsx
@@ -12,7 +12,7 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 //@ts-nocheck
-import { CSSProperties } from 'react';
+import type { CSSProperties } from 'react';
 
 interface LoaderProps {
   fade?: boolean;

--- a/packages/common-ui/src/dialogs/ConfirmUpgrade.tsx
+++ b/packages/common-ui/src/dialogs/ConfirmUpgrade.tsx
@@ -14,7 +14,8 @@
 //@ts-nocheck
 import { Button, Dialog, DialogActions, DialogContent, DialogTitle } from '@mui/material';
 
-import { ADDONS, Plan } from '@northern.tech/store/constants';
+import type { Plan } from '@northern.tech/store/constants';
+import { ADDONS } from '@northern.tech/store/constants';
 
 interface ConfirmUpgradeProps {
   addOns: { name: string }[];

--- a/packages/common-ui/src/dialogs/Feedback.tsx
+++ b/packages/common-ui/src/dialogs/Feedback.tsx
@@ -41,7 +41,7 @@ import { makeStyles } from 'tss-react/mui';
 
 import actions from '@northern.tech/store/actions';
 import { TIMEOUTS } from '@northern.tech/store/constants';
-import { AppDispatch } from '@northern.tech/store/store';
+import type { AppDispatch } from '@northern.tech/store/store';
 import { submitFeedback } from '@northern.tech/store/thunks';
 import { isDarkMode } from '@northern.tech/store/utils';
 

--- a/packages/common-ui/src/forms/AddonSelect.tsx
+++ b/packages/common-ui/src/forms/AddonSelect.tsx
@@ -16,7 +16,8 @@ import { useState } from 'react';
 
 import { Checkbox, FormControl, FormHelperText, InputLabel, MenuItem, Select } from '@mui/material';
 
-import { ADDONS, AddonId } from '@northern.tech/store/constants';
+import type { AddonId } from '@northern.tech/store/constants';
+import { ADDONS } from '@northern.tech/store/constants';
 
 interface AddonSelectProps {
   initialState: AddonId[];

--- a/packages/common/eslint.config.js
+++ b/packages/common/eslint.config.js
@@ -1,3 +1,10 @@
 import eslintConfigReact from '@northern.tech/eslint-config/react.js';
 
-export default eslintConfigReact;
+export default [
+  ...eslintConfigReact,
+  {
+    rules: {
+      '@typescript-eslint/consistent-type-imports': 'error'
+    }
+  }
+];

--- a/packages/common/src/button.tsx
+++ b/packages/common/src/button.tsx
@@ -1,5 +1,5 @@
 //@ts-nocheck
-import React from 'react';
+import type React from 'react';
 
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   children: React.ReactNode;

--- a/packages/store/eslint.config.js
+++ b/packages/store/eslint.config.js
@@ -9,6 +9,9 @@ export default [
         mender_environment: true,
         vi: false
       }
+    },
+    rules: {
+      '@typescript-eslint/consistent-type-imports': 'error'
     }
   }
 ];

--- a/packages/store/src/appSlice/index.ts
+++ b/packages/store/src/appSlice/index.ts
@@ -13,8 +13,10 @@
 //    limitations under the License.
 import type { SnackbarProps } from '@mui/material';
 
-import { SORTING_OPTIONS, SortOptions } from '@northern.tech/store/constants';
-import { PayloadAction, createSlice } from '@reduxjs/toolkit';
+import type { SortOptions } from '@northern.tech/store/constants';
+import { SORTING_OPTIONS } from '@northern.tech/store/constants';
+import type { PayloadAction } from '@reduxjs/toolkit';
+import { createSlice } from '@reduxjs/toolkit';
 
 export const sliceName = 'app';
 

--- a/packages/store/src/appSlice/selectors.ts
+++ b/packages/store/src/appSlice/selectors.ts
@@ -14,7 +14,7 @@
 import { versionCompare } from '@northern.tech/utils/helpers';
 import { createSelector } from '@reduxjs/toolkit';
 
-import { RootState } from '../store';
+import type { RootState } from '../store';
 
 export const getDocsVersion = (state: RootState) => state.app.docsVersion;
 export const getFeatures = (state: RootState) => state.app.features;

--- a/packages/store/src/appSlice/thunks.ts
+++ b/packages/store/src/appSlice/thunks.ts
@@ -13,13 +13,15 @@
 //    limitations under the License.
 import GeneralApi from '@northern.tech/store/api/general-api';
 import { getOfflineThresholdSettings } from '@northern.tech/store/selectors';
-import { AppDispatch, createAppAsyncThunk } from '@northern.tech/store/store';
+import type { AppDispatch } from '@northern.tech/store/store';
+import { createAppAsyncThunk } from '@northern.tech/store/store';
 import { searchDevices } from '@northern.tech/store/thunks';
 import { getComparisonCompatibleVersion } from '@northern.tech/store/utils';
 import { deepCompare, extractErrorMessage } from '@northern.tech/utils/helpers';
 import Cookies from 'universal-cookie';
 
-import { ReleaseData, SaasVersion, SearchState, TagData, VersionRelease, actions, sliceName } from '.';
+import type { ReleaseData, SaasVersion, SearchState, TagData, VersionRelease } from '.';
+import { actions, sliceName } from '.';
 import { getFeatures, getSearchState } from './selectors';
 
 const cookies = new Cookies();

--- a/packages/store/src/auth.ts
+++ b/packages/store/src/auth.ts
@@ -11,7 +11,7 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-import { UserSession } from '@northern.tech/store/usersSlice';
+import type { UserSession } from '@northern.tech/store/usersSlice';
 import Cookies from 'universal-cookie';
 
 import { TIMEOUTS } from './constants';

--- a/packages/store/src/deploymentsSlice/index.ts
+++ b/packages/store/src/deploymentsSlice/index.ts
@@ -11,8 +11,8 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-import { DeviceDeployments as BackendDeviceDeployment } from '@northern.tech/store/api/types/DeviceDeployments';
-import {
+import type { DeviceDeployments as BackendDeviceDeployment } from '@northern.tech/store/api/types/DeviceDeployments';
+import type {
   DeploymentDeployments as BackendDeployment,
   Filter as BackendFilter,
   DeviceWithImage,
@@ -20,7 +20,8 @@ import {
   Limit
 } from '@northern.tech/store/api/types/MenderTypes';
 import { DEVICE_LIST_DEFAULTS } from '@northern.tech/store/constants';
-import { PayloadAction, createSlice } from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
+import { createSlice } from '@reduxjs/toolkit';
 
 import { DEFAULT_PENDING_INPROGRESS_COUNT, DEPLOYMENT_ROUTES, DEPLOYMENT_STATES, deploymentPrototype, limitDefault } from './constants';
 

--- a/packages/store/src/deploymentsSlice/thunks.ts
+++ b/packages/store/src/deploymentsSlice/thunks.ts
@@ -14,7 +14,7 @@
 /*eslint import/namespace: ['error', { allowComputed: true }]*/
 import storeActions from '@northern.tech/store/actions';
 import GeneralApi from '@northern.tech/store/api/general-api';
-import {
+import type {
   DeploymentDeployments as BackendDeployment,
   DeviceWithImage,
   NewDeployment,
@@ -22,16 +22,17 @@ import {
   NewDeploymentV2
 } from '@northern.tech/store/api/types/MenderTypes';
 import { DEVICE_LIST_DEFAULTS, SORTING_OPTIONS, TIMEOUTS, headerNames } from '@northern.tech/store/constants';
-import { SortOptions } from '@northern.tech/store/organizationSlice/types';
+import type { SortOptions } from '@northern.tech/store/organizationSlice/types';
 import { getDevicesById, getGlobalSettings, getOrganization, getUserCapabilities } from '@northern.tech/store/selectors';
-import { AppDispatch, commonErrorHandler, createAppAsyncThunk } from '@northern.tech/store/store';
+import type { AppDispatch } from '@northern.tech/store/store';
+import { commonErrorHandler, createAppAsyncThunk } from '@northern.tech/store/store';
 import { getDeviceAuth, getDeviceById, saveGlobalSettings } from '@northern.tech/store/thunks';
 import { mapTermsToFilters } from '@northern.tech/store/utils';
 import { customSort, deepCompare, isEmpty, standardizePhases } from '@northern.tech/utils/helpers';
 import Tracking from '@northern.tech/utils/tracking';
 import isUUID from 'validator/lib/isUUID';
 
-import {
+import type {
   Deployment,
   DeploymentByStatus,
   DeploymentByStatusKey,
@@ -39,10 +40,9 @@ import {
   DeploymentStatus,
   DeviceDeployment,
   SelectionListState,
-  SelectionState,
-  actions,
-  sliceName
+  SelectionState
 } from '.';
+import { actions, sliceName } from '.';
 import { DEPLOYMENT_ROUTES, DEPLOYMENT_STATES, DEPLOYMENT_TYPES, deploymentPrototype, deploymentsApiUrl, deploymentsApiUrlV2 } from './constants';
 import { getDeploymentsById, getDeploymentsByStatus as getDeploymentsByStatusSelector } from './selectors';
 

--- a/packages/store/src/devicesSlice/index.ts
+++ b/packages/store/src/devicesSlice/index.ts
@@ -19,12 +19,15 @@ import type {
   MonitorConfiguration,
   SortCriteria
 } from '@northern.tech/store/api/types/MenderTypes';
-import { DEVICE_LIST_DEFAULTS, DeviceIssueOptionKey, FilterOperator, SORTING_OPTIONS, SortOptions } from '@northern.tech/store/commonConstants';
-import { DeviceDeployment } from '@northern.tech/store/deploymentsSlice';
+import type { DeviceIssueOptionKey, FilterOperator, SortOptions } from '@northern.tech/store/commonConstants';
+import { DEVICE_LIST_DEFAULTS, SORTING_OPTIONS } from '@northern.tech/store/commonConstants';
+import type { DeviceDeployment } from '@northern.tech/store/deploymentsSlice';
 import { deepCompare, duplicateFilter } from '@northern.tech/utils/helpers';
-import { PayloadAction, createSlice } from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
+import { createSlice } from '@reduxjs/toolkit';
 
-import { ALL_DEVICE_STATES, DEVICE_STATES, DeviceAuthState } from './constants';
+import type { ALL_DEVICE_STATES, DeviceAuthState } from './constants';
+import { DEVICE_STATES } from './constants';
 
 export const sliceName = 'devices';
 export type DeviceSelectedAttribute = { attribute: string; scope: string };

--- a/packages/store/src/devicesSlice/selectors.ts
+++ b/packages/store/src/devicesSlice/selectors.ts
@@ -12,10 +12,11 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import { DEVICE_STATES, UNGROUPED_GROUP } from '@northern.tech/store/constants';
-import { DeviceFilter, DeviceGroup } from '@northern.tech/store/devicesSlice/index';
-import { RootState } from '@northern.tech/store/store';
+import type { RootState } from '@northern.tech/store/store';
 import { duplicateFilter } from '@northern.tech/utils/helpers';
 import { createSelector } from '@reduxjs/toolkit';
+
+import type { DeviceFilter, DeviceGroup } from '.';
 
 export const getAcceptedDevices = (state: RootState) => state.devices.byStatus.accepted;
 export const getDevicesByStatus = (state: RootState) => state.devices.byStatus;

--- a/packages/store/src/devicesSlice/thunks.test.tsx
+++ b/packages/store/src/devicesSlice/thunks.test.tsx
@@ -24,7 +24,7 @@ import { inventoryDevice } from '../../../../tests/__mocks__/deviceHandlers';
 import { defaultState } from '../../../../tests/mockData';
 import { act, mockAbortController } from '../../../../tests/setupTests';
 import { Integration } from '../api/types/Integration';
-import { StatusDeviceauth } from '../api/types/MenderTypes';
+import type { StatusDeviceauth } from '../api/types/MenderTypes';
 import { actions as appActions } from '../appSlice';
 import { EXTERNAL_PROVIDER, TIMEOUTS, UNGROUPED_GROUP } from '../constants';
 import { actions as deploymentActions } from '../deploymentsSlice';

--- a/packages/store/src/devicesSlice/thunks.tsx
+++ b/packages/store/src/devicesSlice/thunks.tsx
@@ -30,11 +30,11 @@ import type {
   SortCriteria,
   StatusDeviceauth
 } from '@northern.tech/store/api/types/MenderTypes';
-import { SearchState } from '@northern.tech/store/appSlice';
+import type { SearchState } from '@northern.tech/store/appSlice';
+import type { DeviceIssueOptionKey } from '@northern.tech/store/constants';
 import {
   DEVICE_FILTERING_OPTIONS,
   DEVICE_LIST_DEFAULTS,
-  DeviceIssueOptionKey,
   EXTERNAL_PROVIDER,
   MAX_PAGE_SIZE,
   SORTING_OPTIONS,
@@ -57,7 +57,8 @@ import {
   getUserCapabilities,
   getUserSettings
 } from '@northern.tech/store/selectors';
-import { AppDispatch, RootState, commonErrorFallback, commonErrorHandler, createAppAsyncThunk } from '@northern.tech/store/store';
+import type { AppDispatch, RootState } from '@northern.tech/store/store';
+import { commonErrorFallback, commonErrorHandler, createAppAsyncThunk } from '@northern.tech/store/store';
 import { getDeviceMonitorConfig, getLatestDeviceAlerts, getSingleDeployment, saveGlobalSettings } from '@northern.tech/store/thunks';
 import {
   convertDeviceListStateToFilters,
@@ -74,7 +75,8 @@ import { isCancel } from 'axios';
 import pluralize from 'pluralize';
 import { v4 as uuid } from 'uuid';
 
-import { Device, DeviceFilter, DeviceGroup, DeviceGroups, DeviceListState, DeviceSelectedAttribute, DeviceStatus, actions, sliceName } from '.';
+import type { Device, DeviceFilter, DeviceGroup, DeviceGroups, DeviceListState, DeviceSelectedAttribute, DeviceStatus } from '.';
+import { actions, sliceName } from '.';
 import {
   ALL_DEVICE_STATES,
   DEVICE_STATES,

--- a/packages/store/src/monitorSlice/index.ts
+++ b/packages/store/src/monitorSlice/index.ts
@@ -11,11 +11,14 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-import { Alert } from '@northern.tech/store/api/types/MenderTypes';
-import { DEVICE_ISSUE_OPTIONS, DEVICE_LIST_DEFAULTS, DeviceIssueOptionKey } from '@northern.tech/store/commonConstants';
-import { PayloadAction, createSlice } from '@reduxjs/toolkit';
+import type { Alert } from '@northern.tech/store/api/types/MenderTypes';
+import type { DeviceIssueOptionKey } from '@northern.tech/store/commonConstants';
+import { DEVICE_ISSUE_OPTIONS, DEVICE_LIST_DEFAULTS } from '@northern.tech/store/commonConstants';
+import type { PayloadAction } from '@reduxjs/toolkit';
+import { createSlice } from '@reduxjs/toolkit';
 
-import { AlertChannelKey, alertChannels } from './constants';
+import type { AlertChannelKey } from './constants';
+import { alertChannels } from './constants';
 
 export const sliceName = 'monitor';
 type IssueCounts = Record<DeviceIssueOptionKey, { filtered: number; total: number }>;

--- a/packages/store/src/monitorSlice/thunks.ts
+++ b/packages/store/src/monitorSlice/thunks.ts
@@ -13,10 +13,12 @@
 //    limitations under the License.
 import storeActions from '@northern.tech/store/actions';
 import Api from '@northern.tech/store/api/general-api';
-import { Alert } from '@northern.tech/store/api/types/MenderTypes';
-import { AlertChannelKey, DEVICE_LIST_DEFAULTS, DeviceIssueOptionKey, TIMEOUTS, alertChannels, headerNames } from '@northern.tech/store/constants';
+import type { Alert } from '@northern.tech/store/api/types/MenderTypes';
+import type { AlertChannelKey, DeviceIssueOptionKey } from '@northern.tech/store/constants';
+import { DEVICE_LIST_DEFAULTS, TIMEOUTS, alertChannels, headerNames } from '@northern.tech/store/constants';
 import { getDeviceFilters, getSearchEndpoint } from '@northern.tech/store/selectors';
-import { AppDispatch, commonErrorFallback, commonErrorHandler, createAppAsyncThunk } from '@northern.tech/store/store';
+import type { AppDispatch } from '@northern.tech/store/store';
+import { commonErrorFallback, commonErrorHandler, createAppAsyncThunk } from '@northern.tech/store/store';
 import { convertDeviceListStateToFilters } from '@northern.tech/store/utils';
 
 import { actions, sliceName } from '.';

--- a/packages/store/src/onboardingSlice/index.ts
+++ b/packages/store/src/onboardingSlice/index.ts
@@ -11,7 +11,8 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-import { PayloadAction, createSlice } from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
+import { createSlice } from '@reduxjs/toolkit';
 
 export const sliceName = 'onboarding';
 

--- a/packages/store/src/onboardingSlice/thunks.ts
+++ b/packages/store/src/onboardingSlice/thunks.ts
@@ -11,20 +11,18 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-import {
-  DEVICE_STATES,
-  OnboardingStep,
-  onboardingSteps as onboardingStepNames,
-  orderedOnboardingSteps as onboardingSteps
-} from '@northern.tech/store/constants';
+import type { OnboardingStep } from '@northern.tech/store/constants';
+import { DEVICE_STATES, onboardingSteps as onboardingStepNames, orderedOnboardingSteps as onboardingSteps } from '@northern.tech/store/constants';
 import { getOnboardingState as getCurrentOnboardingState, getUserCapabilities } from '@northern.tech/store/selectors';
-import { AppDispatch, createAppAsyncThunk } from '@northern.tech/store/store';
+import type { AppDispatch } from '@northern.tech/store/store';
+import { createAppAsyncThunk } from '@northern.tech/store/store';
 import { saveUserSettings } from '@northern.tech/store/thunks';
 import { getDemoDeviceAddress } from '@northern.tech/utils/helpers';
 import Tracking from '@northern.tech/utils/tracking';
 import Cookies from 'universal-cookie';
 
-import { OnboardingApproach, actions, sliceName } from '.';
+import type { OnboardingApproach } from '.';
+import { actions, sliceName } from '.';
 
 const cookies = new Cookies();
 

--- a/packages/store/src/organizationSlice/index.ts
+++ b/packages/store/src/organizationSlice/index.ts
@@ -13,8 +13,9 @@
 //    limitations under the License.
 import type { AuditLog, BillingProfile, Integration, Event as WebhookEvent } from '@northern.tech/store/api/types/MenderTypes';
 import { DEVICE_LIST_DEFAULTS, SORTING_OPTIONS, TENANT_LIST_DEFAULT } from '@northern.tech/store/constants';
-import { AuditLogSelectionState, Card, Organization, OrganizationState, SSOConfig, TenantList } from '@northern.tech/store/organizationSlice/types';
-import { PayloadAction, createSlice } from '@reduxjs/toolkit';
+import type { AuditLogSelectionState, Card, Organization, OrganizationState, SSOConfig, TenantList } from '@northern.tech/store/organizationSlice/types';
+import type { PayloadAction } from '@reduxjs/toolkit';
+import { createSlice } from '@reduxjs/toolkit';
 
 export const sliceName = 'organization';
 

--- a/packages/store/src/organizationSlice/selectors.ts
+++ b/packages/store/src/organizationSlice/selectors.ts
@@ -12,7 +12,7 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import { EXTERNAL_PROVIDER } from '@northern.tech/store/constants';
-import { RootState } from '@northern.tech/store/store';
+import type { RootState } from '@northern.tech/store/store';
 import { createSelector } from '@reduxjs/toolkit';
 
 export const getOrganization = (state: RootState) => state.organization.organization;

--- a/packages/store/src/organizationSlice/thunks.ts
+++ b/packages/store/src/organizationSlice/thunks.ts
@@ -13,7 +13,7 @@
 //    limitations under the License.
 import storeActions from '@northern.tech/store/actions';
 import Api from '@northern.tech/store/api/general-api';
-import {
+import type {
   AuditLog,
   TenantTenantadm as BackendTenant,
   BillingInfo,
@@ -23,9 +23,8 @@ import {
   NewTenant,
   SupportRequest
 } from '@northern.tech/store/api/types/MenderTypes';
+import type { AvailablePlans, ContentType } from '@northern.tech/store/constants';
 import {
-  AvailablePlans,
-  ContentType,
   DEVICE_LIST_DEFAULTS,
   SORTING_OPTIONS,
   TENANT_LIST_DEFAULT,
@@ -35,9 +34,10 @@ import {
   iotManagerBaseURL,
   locations
 } from '@northern.tech/store/constants';
-import { AuditLogSelectionState, SSOConfig, SortOptions, Tenant, TenantList } from '@northern.tech/store/organizationSlice/types';
+import type { AuditLogSelectionState, SSOConfig, SortOptions, Tenant, TenantList } from '@northern.tech/store/organizationSlice/types';
 import { getCurrentSession, getTenantCapabilities, getTenantsList } from '@northern.tech/store/selectors';
-import { AppDispatch, commonErrorFallback, commonErrorHandler, createAppAsyncThunk } from '@northern.tech/store/store';
+import type { AppDispatch } from '@northern.tech/store/store';
+import { commonErrorFallback, commonErrorHandler, createAppAsyncThunk } from '@northern.tech/store/store';
 import { getDeviceLimit, setFirstLoginAfterSignup } from '@northern.tech/store/thunks';
 import { dateRangeToUnix, deepCompare } from '@northern.tech/utils/helpers';
 import dayjs from 'dayjs';

--- a/packages/store/src/organizationSlice/types.ts
+++ b/packages/store/src/organizationSlice/types.ts
@@ -20,10 +20,9 @@ import type {
   Integration,
   SAMLMetadata
 } from '@northern.tech/store/api/types/MenderTypes';
-import { AvailableAddon } from '@northern.tech/store/appSlice/constants';
-import { SSO_TYPES } from '@northern.tech/store/organizationSlice/constants';
+import type { AvailableAddon, SORTING_OPTIONS } from '@northern.tech/store/constants';
 
-import { SORTING_OPTIONS } from '../commonConstants';
+import type { SSO_TYPES } from './constants';
 
 export interface Card {
   brand?: string;

--- a/packages/store/src/releasesSlice/index.ts
+++ b/packages/store/src/releasesSlice/index.ts
@@ -11,11 +11,11 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
+import type { Artifact as BackendArtifact, Release as BackendRelease } from '@northern.tech/store/api/types/MenderTypes';
 import { DEVICE_LIST_DEFAULTS, SORTING_OPTIONS } from '@northern.tech/store/constants';
-import { PayloadAction, createSlice } from '@reduxjs/toolkit';
-
-import { Artifact as BackendArtifact, Release as BackendRelease } from '../api/types/MenderTypes';
-import { SortOptions } from '../organizationSlice/types';
+import type { SortOptions } from '@northern.tech/store/organizationSlice/types';
+import type { PayloadAction } from '@reduxjs/toolkit';
+import { createSlice } from '@reduxjs/toolkit';
 
 export type Artifact = BackendArtifact & { installCount?: number; url?: string };
 export type Release = BackendRelease & { artifacts: Artifact[]; name: string };

--- a/packages/store/src/releasesSlice/selectors.ts
+++ b/packages/store/src/releasesSlice/selectors.ts
@@ -11,11 +11,10 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-import { RootState } from '@northern.tech/store/store';
+import type { Release } from '@northern.tech/store/api/types/Release';
+import type { RootState } from '@northern.tech/store/store';
 import { listItemMapper } from '@northern.tech/store/utils';
 import { createSelector } from '@reduxjs/toolkit';
-
-import { Release } from '../api/types/Release';
 
 const getSelectedReleaseId = (state: RootState) => state.releases.selectedRelease;
 export const getReleasesById = (state: RootState) => state.releases.byId;

--- a/packages/store/src/releasesSlice/thunks.ts
+++ b/packages/store/src/releasesSlice/thunks.ts
@@ -13,7 +13,7 @@
 //    limitations under the License.
 import storeActions from '@northern.tech/store/actions';
 import GeneralApi from '@northern.tech/store/api/general-api';
-import { ArtifactUpdate, ReleaseUpdate, Tags } from '@northern.tech/store/api/types/MenderTypes';
+import type { ArtifactUpdate, ReleaseUpdate, Tags } from '@northern.tech/store/api/types/MenderTypes';
 import {
   DEVICE_LIST_DEFAULTS,
   SORTING_OPTIONS,
@@ -24,15 +24,17 @@ import {
   headerNames
 } from '@northern.tech/store/constants';
 import { formatReleases } from '@northern.tech/store/locationutils';
-import { SortOptions } from '@northern.tech/store/organizationSlice/types';
+import type { SortOptions } from '@northern.tech/store/organizationSlice/types';
 import { getSearchEndpoint } from '@northern.tech/store/selectors';
-import { AppDispatch, commonErrorFallback, commonErrorHandler, createAppAsyncThunk } from '@northern.tech/store/store';
+import type { AppDispatch } from '@northern.tech/store/store';
+import { commonErrorFallback, commonErrorHandler, createAppAsyncThunk } from '@northern.tech/store/store';
 import { convertDeviceListStateToFilters, progress } from '@northern.tech/store/utils';
 import { customSort, deepCompare, duplicateFilter, extractSoftwareItem } from '@northern.tech/utils/helpers';
 import { isCancel } from 'axios';
 import { v4 as uuid } from 'uuid';
 
-import { Artifact, Release, ReleaseSliceType, ReleasesList, actions, sliceName } from '.';
+import type { Artifact, Release, ReleaseSliceType, ReleasesList } from '.';
+import { actions, sliceName } from '.';
 import { ARTIFACT_GENERATION_TYPE } from './constants';
 import { getReleasesById } from './selectors';
 

--- a/packages/store/src/usersSlice/constants.ts
+++ b/packages/store/src/usersSlice/constants.ts
@@ -13,7 +13,7 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-import { PermissionSet as BackendPermissionSet, Role as BackendRole, RolePermission, RoleUseradm } from '@northern.tech/store/api/types/MenderTypes';
+import type { PermissionSet as BackendPermissionSet, Role as BackendRole, RolePermission, RoleUseradm } from '@northern.tech/store/api/types/MenderTypes';
 import { ALL_DEVICES, ALL_RELEASES, apiUrl, emptyUiPermissions } from '@northern.tech/store/constants';
 
 export const useradmApiUrlv1 = `${apiUrl.v1}/useradm`;

--- a/packages/store/src/usersSlice/index.ts
+++ b/packages/store/src/usersSlice/index.ts
@@ -11,11 +11,13 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-import { User as BackendUser, DeploymentPhase, TenantInfo, TenantsIdName } from '@northern.tech/store/api/types/MenderTypes';
-import { FilterOperator } from '@northern.tech/store/commonConstants';
-import { PayloadAction, createSlice } from '@reduxjs/toolkit';
+import type { User as BackendUser, DeploymentPhase, TenantInfo, TenantsIdName } from '@northern.tech/store/api/types/MenderTypes';
+import type { FilterOperator } from '@northern.tech/store/constants';
+import type { PayloadAction } from '@reduxjs/toolkit';
+import { createSlice } from '@reduxjs/toolkit';
 
-import { PermissionSet, READ_STATES, ReadState, Role, defaultPermissionSets, rolesById } from './constants';
+import type { PermissionSet, ReadState, Role } from './constants';
+import { READ_STATES, defaultPermissionSets, rolesById } from './constants';
 
 export const sliceName = 'users';
 export type User = BackendUser & TenantInfo & { tenants?: TenantsIdName };

--- a/packages/store/src/usersSlice/thunks.test.ts
+++ b/packages/store/src/usersSlice/thunks.test.ts
@@ -18,7 +18,8 @@ import { act } from '@testing-library/react';
 import configureMockStore from 'redux-mock-store';
 import { thunk } from 'redux-thunk';
 import Cookies from 'universal-cookie';
-import { Mock, describe, expect, it, vi } from 'vitest';
+import type { Mock } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { actions } from '.';
 import { accessTokens, defaultPassword, defaultState, receivedPermissionSets, receivedRoles, testSsoId, userId } from '../../../../tests/mockData';

--- a/packages/store/src/usersSlice/thunks.ts
+++ b/packages/store/src/usersSlice/thunks.ts
@@ -13,28 +13,31 @@
 //    limitations under the License.
 import storeActions from '@northern.tech/store/actions';
 import GeneralApi from '@northern.tech/store/api/general-api';
-import { PermissionSetWithScope, PersonalAccessToken, RolePermission, RolePermissionObject } from '@northern.tech/store/api/types/MenderTypes';
+import type { PermissionSetWithScope, PersonalAccessToken, RolePermission, RolePermissionObject } from '@northern.tech/store/api/types/MenderTypes';
 import UsersApi from '@northern.tech/store/api/users-api';
 import { cleanUp, getSessionInfo, maxSessionAge, setSessionInfo } from '@northern.tech/store/auth';
+import type {
+  PermissionObject,
+  PermissionSetId,
+  ReadState,
+  ScopedPermissionsByAreaKey,
+  UiPermissionsByAreaKey,
+  UiPermissionsByIdKey
+} from '@northern.tech/store/constants';
 import {
   ALL_RELEASES,
   APPLICATION_JSON_CONTENT_TYPE,
   APPLICATION_JWT_CONTENT_TYPE,
-  PermissionObject,
-  PermissionSetId,
-  ReadState,
   SSO_TYPES,
-  ScopedPermissionsByAreaKey,
   TIMEOUTS,
-  UiPermissionsByAreaKey,
-  UiPermissionsByIdKey,
   apiRoot,
   emptyRole,
   emptyUiPermissions,
   tenantadmApiUrlv2
 } from '@northern.tech/store/constants';
 import { getOnboardingState, getOrganization, getTooltipsState, getUserSettings as getUserSettingsSelector } from '@northern.tech/store/selectors';
-import { AppDispatch, commonErrorFallback, commonErrorHandler, createAppAsyncThunk } from '@northern.tech/store/store';
+import type { AppDispatch } from '@northern.tech/store/store';
+import { commonErrorFallback, commonErrorHandler, createAppAsyncThunk } from '@northern.tech/store/store';
 import { setOfflineThreshold } from '@northern.tech/store/thunks';
 import { mergePermissions } from '@northern.tech/store/utils';
 import { duplicateFilter, extractErrorMessage, isEmpty } from '@northern.tech/utils/helpers';
@@ -42,21 +45,24 @@ import { clearAllRetryTimers } from '@northern.tech/utils/retrytimer';
 import hashString from 'md5';
 import Cookies from 'universal-cookie';
 
-import { CustomColumn, GlobalSettings, User, UserSettings, actions, sliceName } from '.';
-import {
+import type { CustomColumn, GlobalSettings, User, UserSettings } from '.';
+import { actions, sliceName } from '.';
+import type {
   AnyPermission,
   AuditLogPermission,
   DeploymentPermission,
   GroupsPermission,
-  OWN_USER_ID,
   PermissionSet,
-  PermissionTypes,
-  READ_STATES,
   ReleasesPermission,
   Role,
-  USER_LOGOUT,
   UiPermissions,
-  UserManagementPermission,
+  UserManagementPermission
+} from './constants';
+import {
+  OWN_USER_ID,
+  PermissionTypes,
+  READ_STATES,
+  USER_LOGOUT,
   defaultPermissionSets,
   rolesById as defaultRolesById,
   itemUiPermissionsReducer,

--- a/packages/store/src/utils.ts
+++ b/packages/store/src/utils.ts
@@ -12,18 +12,12 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 // @ts-nocheck
-import { DeviceAttribute } from '@northern.tech/store/api/types/DeviceAttribute';
-import { DeviceFilter, DeviceGroup, InventoryAttributes } from '@northern.tech/store/devicesSlice';
+import type { DeviceAttribute } from '@northern.tech/store/api/types/DeviceAttribute';
+import type { DeviceFilter, DeviceGroup, InventoryAttributes } from '@northern.tech/store/devicesSlice';
 import { duplicateFilter, yes } from '@northern.tech/utils/helpers';
 
-import {
-  ATTRIBUTE_SCOPES,
-  DEVICE_FILTERING_OPTIONS,
-  DEVICE_ISSUE_OPTIONS,
-  DEVICE_LIST_MAXIMUM_LENGTH,
-  DeviceIssueOptionKey,
-  emptyUiPermissions
-} from './commonConstants';
+import type { DeviceIssueOptionKey } from './commonConstants';
+import { ATTRIBUTE_SCOPES, DEVICE_FILTERING_OPTIONS, DEVICE_ISSUE_OPTIONS, DEVICE_LIST_MAXIMUM_LENGTH, emptyUiPermissions } from './commonConstants';
 import {
   DARK_MODE,
   DEPLOYMENT_STATES,

--- a/packages/utils/eslint.config.js
+++ b/packages/utils/eslint.config.js
@@ -1,3 +1,10 @@
 import eslintConfigLibrary from '@northern.tech/eslint-config/library.js';
 
-export default eslintConfigLibrary;
+export default [
+  ...eslintConfigLibrary,
+  {
+    rules: {
+      '@typescript-eslint/consistent-type-imports': 'error'
+    }
+  }
+];


### PR DESCRIPTION
consider this an RFC and mostly due to the potential to slightly decrease the bundle size (thus also only in the package configs, not in the packaged config)