### PR TITLE
Fixed CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # Default owners for everything in the repo
 
-- @NorthernTechHQ/frontend-dependabot-reviewers
+* @NorthernTechHQ/frontend-dependabot-reviewers


### PR DESCRIPTION
Looks like this is not working:

https://github.com/NorthernTechHQ/nt-gui/pull/242

According to docs, I guess what we need is asterisk;

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-file-location