### PR TITLE
fix(themes): made use of more specific alert error override to ensure readable alerts

### DIFF
--- a/packages/themes/src/Mender/common.ts
+++ b/packages/themes/src/Mender/common.ts
@@ -119,9 +119,12 @@ export const overrides = {
   ...componentProps,
   MuiAlert: {
     styleOverrides: {
-      colorError: ({ theme }) => ({
-        background: theme.palette.mode === 'light' ? lighten(theme.palette.error.main, 0.95) : '',
-        color: theme.palette.mode === 'light' ? theme.palette.text.primary : ''
+      root: ({ theme, ownerState }) => ({
+        ...(ownerState.severity === 'error' &&
+          theme.palette.mode === 'light' && {
+            backgroundColor: lighten(theme.palette.error.main, 0.95),
+            color: theme.palette.text.primary
+          })
       })
     }
   },


### PR DESCRIPTION
unfortunately the color override didn't work as intended in the context of the Mender UI, despite checking it locally 🤨 - this should be more focused on the concrete usage 😕 