### PR TITLE
fix(store): guard deployment name decoding so a stray % can't break the deployments list

### DIFF
--- a/packages/store/src/deploymentsSlice/thunks.test.ts
+++ b/packages/store/src/deploymentsSlice/thunks.test.ts
@@ -35,6 +35,7 @@ import {
   resetDeviceDeployments,
   saveDeltaDeploymentsConfig,
   setDeploymentsState,
+  transformDeployments,
   updateDeploymentControlMap
 } from './thunks';
 
@@ -442,5 +443,28 @@ describe('deployment actions', () => {
       expect(storeActions.length).toEqual(expectedActions.length);
       expectedActions.forEach((action, index) => expect(storeActions[index]).toMatchObject(action));
     });
+  });
+});
+
+describe('transformDeployments', () => {
+  const baseDeployment = defaultState.deployments.byId.d2;
+
+  it('preserves the raw name when a deployment name is not a valid URI component', () => {
+    // Regression test: a deployment whose name contains an invalid percent-escape (e.g. a
+    // trailing '%2', which is a '%' followed by a single digit rather than two hex digits)
+    // made decodeURIComponent throw URIError. As transformDeployments runs inside
+    // getDeploymentsByStatus without a catch, that rejected the whole action and broke the
+    // entire deployments list for the tenant.
+    const malformedName = 'app_1.2.3.45.6.7%2';
+    const deployments = [{ ...baseDeployment, id: 'malformed', name: malformedName }] as unknown as Parameters<typeof transformDeployments>[0];
+    const { deployments: result, deploymentIds } = transformDeployments(deployments, {});
+    expect(deploymentIds).toEqual(['malformed']);
+    expect(result.malformed.name).toEqual(malformedName);
+  });
+
+  it('still decodes valid percent-encoded deployment names', () => {
+    const deployments = [{ ...baseDeployment, id: 'encoded', name: 'release%20v1' }] as unknown as Parameters<typeof transformDeployments>[0];
+    const { deployments: result } = transformDeployments(deployments, {});
+    expect(result.encoded.name).toEqual('release v1');
   });
 });

--- a/packages/store/src/deploymentsSlice/thunks.ts
+++ b/packages/store/src/deploymentsSlice/thunks.ts
@@ -57,7 +57,7 @@ export const deriveDeploymentGroup = ({ filter, group, groups = [], name }: Depl
   group || (groups.length === 1 && !isUUID(name)) ? groups[0] : filter?.name;
 
 type ReceivedDeployment = BackendDeploymentV1 | BackendDeploymentV2;
-const transformDeployments = (deployments: ReceivedDeployment[], deploymentsById: Record<string, Deployment>) =>
+export const transformDeployments = (deployments: ReceivedDeployment[], deploymentsById: Record<string, Deployment>) =>
   deployments.sort(customSort(true, 'created')).reduce<{ deploymentIds: string[]; deployments: Record<string, Deployment> }>(
     (accu, item) => {
       const filter = item.filter;

--- a/packages/store/src/deploymentsSlice/thunks.ts
+++ b/packages/store/src/deploymentsSlice/thunks.ts
@@ -57,6 +57,16 @@ export const deriveDeploymentGroup = ({ filter, group, groups = [], name }: Depl
   group || (groups.length === 1 && !isUUID(name)) ? groups[0] : filter?.name;
 
 type ReceivedDeployment = BackendDeploymentV1 | BackendDeploymentV2;
+// a deployment name can legitimately contain a bare '%' or an otherwise invalid escape (e.g. a
+// trailing '%2') that decodeURIComponent rejects with a URIError. Falling back to the raw name
+// keeps a single bad name from rejecting getDeploymentsByStatus and breaking the entire list.
+const decodeDeploymentName = (name: string) => {
+  try {
+    return decodeURIComponent(name);
+  } catch {
+    return name;
+  }
+};
 export const transformDeployments = (deployments: ReceivedDeployment[], deploymentsById: Record<string, Deployment>) =>
   deployments.sort(customSort(true, 'created')).reduce<{ deploymentIds: string[]; deployments: Record<string, Deployment> }>(
     (accu, item) => {
@@ -68,7 +78,7 @@ export const transformDeployments = (deployments: ReceivedDeployment[], deployme
         // TODO: explicitly set filter term types to address scope type mismatch in deployment specs
         // @ts-expect-error: type misalignment in filter terms type
         filter: filter ? { ...filter, name: filter.name ?? filter.id, filters: mapTermsToFilters(filter.terms) } : undefined,
-        name: decodeURIComponent(item.name)
+        name: decodeDeploymentName(item.name)
       };
       // deriving the group in a second step to potentially make use of the merged data from the existing group state + the decoded name
       deployment = { ...deployment, group: deriveDeploymentGroup(deployment) };


### PR DESCRIPTION
## Problem

The Deployments list (Active / Pending tab) fails to load **entirely** when any deployment in the returned page has a name containing an invalid percent-escape — most easily a trailing `%` or an incomplete sequence like `%2`. The console shows:

```
Rejection in action: {type: 'deployments/getDeploymentsByStatus/rejected', payload: undefined, error: {…}}
URIError: URI malformed
```

`transformDeployments` decodes every deployment name unconditionally (`name: decodeURIComponent(item.name)`), and `getDeploymentsByStatus` has no `.catch`, so a single un-decodeable name rejects the whole thunk and poisons the entire page. Aborting the offending deployment doesn't help — the finished/past list uses the same transform, so the failure just relocates.

Reported via support (hosted); the trigger was a version-style deployment name ending in an incomplete escape (`…%2`).

## This PR

- **First commit** (`test`): a regression test for `transformDeployments`, plus exporting the helper so it can be unit-tested (matching the already-exported `deriveDeploymentGroup`). This commit is **red**.
- **Second commit** (`fix`): guard the decode, falling back to the raw name when it isn't a valid URI component. Test goes **green**, and valid percent-encoded names (e.g. `release%20v1`) still decode.

## Notes

Same class of bug as MEN-7395 (special characters in release names break the releases view) — worth auditing the other `decodeURIComponent(name)` call sites (releases, groups) in a follow-up.

Ticket: ME-682

🤖 Generated with [Claude Code](https://claude.com/claude-code)
