### PR TITLE
Ci/trusted publishing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -90,7 +90,7 @@ build:
 
 changelog:
   stage: changelog
-  image: 'registry.gitlab.com/northern.tech/mender/mender-test-containers:release-please-v1-master'
+  image: 'registry.gitlab.com/northern.tech/mender/mender-test-containers/release-please:master'
   variables:
     GIT_DEPTH: 0 # Always get the full history
     GIT_STRATEGY: clone
@@ -149,7 +149,7 @@ changelog:
 
 release:
   stage: release
-  image: 'registry.gitlab.com/northern.tech/mender/mender-test-containers:release-please-v1-master'
+  image: 'registry.gitlab.com/northern.tech/mender/mender-test-containers/release-please:master'
   rules:
     - if: $CI_COMMIT_BRANCH == $DEFAULT_BRANCH
   needs:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -157,10 +157,9 @@ release:
   id_tokens:
     NPM_ID_TOKEN:
       aud: "npm:registry.npmjs.org"
-    SIGSTORE_ID_TOKEN:
-      aud: sigstore
   before_script:
     - apt-get update && apt-get install -y jq
+    # TODO remove together with the NPM_AUTH_TOKEN variable once OIDC publishing is confirmed
     - echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
   script:
     - npm ci
@@ -180,7 +179,7 @@ release:
           echo "INFO - ${PKG_NAME}@${PKG_VERSION} already published, skipping";
         else
           echo "INFO - publishing ${PKG_NAME}@${PKG_VERSION}";
-          npm publish;
+          npm publish --provenance=false --loglevel verbose;
         fi
         cd ../..;
       done


### PR DESCRIPTION
triggered by the OIDC adoption in other projects & [this comment](https://github.com/orgs/community/discussions/174507#discussioncomment-17147707) -> there is a chance we can rely on trusted publishing after all - albeit without provenance attestation 🤞